### PR TITLE
Fix default storage class value

### DIFF
--- a/workload_runner.py
+++ b/workload_runner.py
@@ -56,7 +56,7 @@ def main() -> None:
                         type=str,
                         help="Namespace where the OCS components are running")
     parser.add_argument("-s", "--storageclass",
-                        default="openshift-storage-ceph-rbd",
+                        default="ocs-storagecluster-ceph-rbd",
                         type=str,
                         help="StorageClassName for the workload's PVCs")
     parser.add_argument("-z", "--sleep-on-error",


### PR DESCRIPTION
Default storage class changed to ocs-storagecluster-ceph-rbd
Fixes #1 

Signed-off-by: Jilju Joy <jijoy@redhat.com>