### PR TITLE
Update default cephcluster name

### DIFF
--- a/chaos_runner.py
+++ b/chaos_runner.py
@@ -76,7 +76,7 @@ def main() -> None:
                         type=float,
                         help="Steady-state check interval (sec)")
     parser.add_argument("--cephcluster-name",
-                        default="openshift-storage-cephcluster",
+                        default="ocs-storagecluster-cephcluster",
                         type=str,
                         help="Name of the cephcluster object")
     parser.add_argument("-l", "--log-dir",


### PR DESCRIPTION
Updating default value of cephcluster name to "ocs-storagecluster-cephcluster".

Signed-off-by: Jilju Joy <jijoy@redhat.com>