### PR TITLE
Enable workload_runner to use more than one storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ optional arguments:
   --oc OC               Path/executable for the oc command
   --ocs-namespace OCS_NAMESPACE
                         Namespace where the OCS components are running
-  -s STORAGECLASS, --storageclass STORAGECLASS
-                        StorageClassName for the workload's PVCs
+  -s, --storageclasses
+                        StorageClass names for the workload's PVCs
   -z, --sleep-on-error  On error, sleep forever instead of exit
   -t, --runtime         Run time in seconds
 ```

--- a/osio.py
+++ b/osio.py
@@ -45,7 +45,7 @@ class UnhealthyDeployment(Exception):
 
 
 def start(namespace: str,  # pylint: disable=too-many-arguments
-          storage_classes: list,
+          storage_classes: List[str],
           access_mode: str,
           interarrival: float,
           lifetime: float,
@@ -54,7 +54,7 @@ def start(namespace: str,  # pylint: disable=too-many-arguments
           kernel_slots: int,
           kernel_untar: float,
           kernel_rm: int,
-          workload_image: str) -> list:
+          workload_image: str) -> List[Event]:
     """
     Start the workload.
 
@@ -99,7 +99,7 @@ def start(namespace: str,  # pylint: disable=too-many-arguments
     return [Creator(namespace=namespace,
                    storage_class=storage_class,
                    access_mode=access_mode,
-                   interarrival=interarrival,
+                   interarrival=interarrival*len(storage_classes),
                    lifetime=lifetime,
                    active=active,
                    idle=idle,

--- a/workload_runner.py
+++ b/workload_runner.py
@@ -133,8 +133,7 @@ def main() -> None:
                         kernel_rm=CLI_ARGS.osio_kernel_rm,
                         workload_image=CLI_ARGS.osio_image)
 
-    for event_item in events:
-        dispatch.add(event_item)
+    dispatch.add(*events)
 
     try:
         dispatch.run(runtime=CLI_ARGS.runtime)

--- a/workload_runner.py
+++ b/workload_runner.py
@@ -55,10 +55,10 @@ def main() -> None:
                         default="openshift-storage",
                         type=str,
                         help="Namespace where the OCS components are running")
-    parser.add_argument("-s", "--storageclass",
-                        default="ocs-storagecluster-ceph-rbd",
-                        type=str,
-                        help="StorageClassName for the workload's PVCs")
+    parser.add_argument("-s", "--storageclasses",
+                        default=["ocs-storagecluster-ceph-rbd", "ocs-storagecluster-cephfs"],
+                        nargs="+",
+                        help="List of StorageClass names for the workload's PVCs")
     parser.add_argument("-z", "--sleep-on-error",
                         action="store_true",
                         help="On error, sleep forever instead of exit")
@@ -121,17 +121,21 @@ def main() -> None:
 
     dispatch = event.Dispatcher()
     dispatch.add(*osio.resume(CLI_ARGS.namespace))
-    dispatch.add(osio.start(namespace=CLI_ARGS.namespace,
-                            storage_class=CLI_ARGS.storageclass,
-                            access_mode=CLI_ARGS.accessmode,
-                            interarrival=CLI_ARGS.osio_interarrival,
-                            lifetime=CLI_ARGS.osio_lifetime,
-                            active=CLI_ARGS.osio_active_time,
-                            idle=CLI_ARGS.osio_idle_time,
-                            kernel_slots=CLI_ARGS.osio_kernel_slots,
-                            kernel_untar=CLI_ARGS.osio_kernel_untar,
-                            kernel_rm=CLI_ARGS.osio_kernel_rm,
-                            workload_image=CLI_ARGS.osio_image))
+    events = osio.start(namespace=CLI_ARGS.namespace,
+                        storage_classes=CLI_ARGS.storageclasses,
+                        access_mode=CLI_ARGS.accessmode,
+                        interarrival=CLI_ARGS.osio_interarrival,
+                        lifetime=CLI_ARGS.osio_lifetime,
+                        active=CLI_ARGS.osio_active_time,
+                        idle=CLI_ARGS.osio_idle_time,
+                        kernel_slots=CLI_ARGS.osio_kernel_slots,
+                        kernel_untar=CLI_ARGS.osio_kernel_untar,
+                        kernel_rm=CLI_ARGS.osio_kernel_rm,
+                        workload_image=CLI_ARGS.osio_image)
+
+    for event_item in events:
+        dispatch.add(event_item)
+
     try:
         dispatch.run(runtime=CLI_ARGS.runtime)
     except osio.UnhealthyDeployment:


### PR DESCRIPTION
Enable workload_runner to use more than one storage class.
Added ```['ocs-storagecluster-ceph-rbd', 'ocs-storagecluster-cephfs']``` as the default value of the storage classes.
Closes #14 
Signed-off-by: Jilju Joy <jijoy@redhat.com>