### PR TITLE
Allow chaos runner to monitor deployment on another cluster

### DIFF
--- a/.github/workflows/workload-generator.yml
+++ b/.github/workflows/workload-generator.yml
@@ -51,7 +51,7 @@ jobs:
           kubectl get nodes
 
       - name: tox
-        run: tox -v -e py36,py36-kubetest,srclint
+        run: tox -v -e lint,test,kubetest,srclint
 
       - name: Lint helm chart
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 /venv
 *.pyc
+.test
 /.mypy_cache/
 /.tox/
 /.vscode/

--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,8 @@
 """Test fixtures for pytest."""
 
-import random
-
 import kubernetes
-import kubernetes.client as k8s
 import pytest
 
-import kube
 
 def pytest_addoption(parser):
     """Add command-line options to pytest."""
@@ -22,6 +18,9 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     """Define kube_required pytest mark."""
     config.addinivalue_line("markers", "kube_required: mark test as requiring kubernetes")
+    # Allow non-kube tests to run.
+    if not config.getoption("--run-kube-tests"):
+        kubernetes.config.load_kube_config = object
 
 def pytest_collection_modifyitems(config, items):
     """Only run kube_required tests when --run-kube-tests is used."""
@@ -35,47 +34,3 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "benchmark" in item.keywords:
                 item.add_marker(skip_bench)
-
-
-
-@pytest.fixture(scope="module")
-def load_kubeconfig():
-    """Load the kube configuration so we can contact the cluster."""
-    kubernetes.config.load_kube_config()
-
-
-@pytest.fixture(params=["csi-cephfs", "csi-rbd", "gp2"])
-def storageclass_iterator(request):
-    """Allow a test to iterate across a number of storage classes."""
-    return request.param
-
-
-@pytest.fixture
-# pylint: disable=redefined-outer-name
-# pylint: disable=unused-argument
-def unique_namespace(request, load_kubeconfig):
-    """
-    Create a namespace in which to run a test.
-
-    This will create a namespace with a random name and automatically delete it
-    at the end of the test.
-
-    Returns:
-        dict describing the namespace that has been created for this test.
-
-    """
-    core_v1 = k8s.CoreV1Api()
-    ns_name = f"ns-{random.randrange(999999999)}"
-    namespace = kube.call(core_v1.create_namespace,
-                          body={
-                              "metadata": {
-                                  "name": ns_name
-                                  }
-                              })
-
-    def teardown():
-        kube.call(core_v1.delete_namespace,
-                  name=namespace["metadata"]["name"],
-                  body=k8s.V1DeleteOptions())
-    request.addfinalizer(teardown)
-    return namespace

--- a/helm/ocs-monkey-generator/templates/rbac.yaml
+++ b/helm/ocs-monkey-generator/templates/rbac.yaml
@@ -7,7 +7,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: '{{ template "ocs-monkey-generator.fullname" . }}'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,1 @@
-kubernetes
-#kubernetes==9.0.0  # ocs-ci requires 9.0.0
-#requests==2.21.0  # ocs-ci requires 2.21.0
-#urllib3<1.25,>=1.21.1  # due to requests 2.21.0
-#git+https://github.com/reportportal/client-Python.git@master#egg=reportportal-client  # needed by ocs-ci
-mypy
-pylint
-pytest
-pytest-benchmark
-#git+https://github.com/red-hat-storage/ocs-ci.git#egg=ocs-ci
+kubernetes>=23.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,10 @@
+[tox]
+envlist = lint, test, srclint
+minversion = 3.25.0
+skipsdist = True
+
 [testenv]
-deps =
-        -r requirements.txt
+basepython = python3.6
 lint_paths =
         chaos_runner.py
         event.py
@@ -13,27 +17,41 @@ lint_paths =
         osio-workload/workload.py
         workload_runner.py
         util.py
+src_deps =
+    -r requirements.txt
+test_base_deps =
+    pytest==7.0.1
+
+[testenv:lint]
+deps =
+    {[testenv]src_deps}
+    mypy==0.950
+    pylint==2.13.9
 commands =
-    mypy --strict {[testenv]lint_paths}
     pylint {[testenv]lint_paths}
+    mypy --strict {[testenv]lint_paths}
+
+[testenv:test]
+deps =
+    {[testenv]src_deps}
+    {[testenv]test_base_deps}
+    pytest-benchmark==3.4.1
+commands =
     pytest
 
-[testenv:py36-kubetest]
+[testenv:kubetest]
 deps =
-        -r requirements.txt
+    {[testenv]src_deps}
+    {[testenv]test_base_deps}
 commands =
     pytest --run-kube-tests
 passenv = KUBECONFIG
 
 [testenv:srclint]
-basepython=python3
+allowlist_externals={toxinidir}/.travis/pre-commit.sh
 commands =
     {toxinidir}/.travis/pre-commit.sh
 passenv = *
-
-[tox]
-envlist = py36, srclint
-skipsdist = True
 
 [pytest]
 addopts = --strict-markers --doctest-modules

--- a/util.py
+++ b/util.py
@@ -3,12 +3,13 @@
 import logging
 import os
 import time
+from typing import List
 
 def setup_logging(log_dir: str) -> None:
     """Initializes logging to file & stdout."""
     os.mkdir(log_dir)
 
-    handlers = [
+    handlers: List[logging.Handler] = [
         logging.FileHandler(os.path.join(log_dir, "runner.log")),
         logging.StreamHandler()
     ]


### PR DESCRIPTION
As provider/consumer addon is a multicluster scenario, when running workload on consumer and chaos on provider,
we need to allow chaos runner to monitor the health deployment on consumer cluster.

Also included:
- Fix: update rbac apiVersion
- Avoid lint/test deps when installing app requirements
- Cleanup:
    - tox.ini refactoring: only install the required deps for each check.
    - Fix: allow non-kube unit tests to run
      (before they failed trying to import the kubeconfig file).
    - conftest.py: remove dead code.
    - util.py: fix typing.