### PR TITLE
Chaos runner: set --runtime default to 0 (infinite)

### DIFF
--- a/helm/ocs-monkey-generator/values.yaml
+++ b/helm/ocs-monkey-generator/values.yaml
@@ -24,7 +24,7 @@ chaos:
   cephclusterName: ocs-storagecluster-cephcluster
   mitigationTimeout: 900
   mttf: 150
-  runtime: 7200
+  runtime: 0
 
 workload:
   accessmode: ReadWriteOnce


### PR DESCRIPTION
Follow-up PR that implements [this suggestion](https://github.com/red-hat-storage/ocs-monkey/pull/18#issuecomment-1143653832).

Signed-off-by: Alfonso Martínez <almartin@redhat.com>